### PR TITLE
Read profile script from the user's home directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,12 +48,22 @@ name = "gynjo"
 version = "0.1.0"
 dependencies = [
  "bigdecimal",
+ "home",
  "itertools",
  "lazy_static",
  "logos",
  "num",
  "num-traits",
  "rstest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -272,3 +282,25 @@ name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 bigdecimal = "0.2"
+home = "0.5"
 itertools = "0.9"
 lazy_static = "1.4"
 logos = "0.11"

--- a/README.md
+++ b/README.md
@@ -222,3 +222,5 @@ Very simple textual importation is supported via `import` expressions. The argum
 ```
 >> import "path/to/lib.gynj" // Executes the script at "path/to/lib.gynj"
 ```
+
+At startup, the interpreter will check for `.gynjo_profile` in the user's home directory and execute it if present.

--- a/src/env.rs
+++ b/src/env.rs
@@ -79,10 +79,3 @@ impl Env {
 		})
 	}
 }
-
-/// Attempts to import library at `filename` into `env`. Displays an error message on failure.
-pub fn import_lib_from_path(env: &mut SharedEnv, filename: &str) {
-	if let Err(err) = eval(env, &format!("import {}", filename)) {
-		println!("Error importing {}: {}", filename, err);
-	}
-}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -511,12 +511,12 @@ fn eval_import(env: &mut SharedEnv, target: Expr) -> EvalResult {
 	match eval_expr(env, target)? {
 		Val::Prim(Prim::Text(filename)) => {
 			let filename: String = filename.into();
-			let lib_text =
+			let source =
 				std::fs::read_to_string(&filename).map_err(|err| RtErr::CouldNotOpenFile {
 					filename: filename.clone(),
 					file_error: err.to_string(),
 				})?;
-			eval(env, &lib_text).map_err(|err| RtErr::LibErr {
+			eval(env, &source).map_err(|err| RtErr::LibErr {
 				lib_name: filename,
 				nested_error: Box::new(err),
 			})

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,15 @@ use std::io::{self, Write};
 fn main() {
 	// Create environment with core libs.
 	let mut env = env::Env::with_core_libs();
-	// Try to load user's profile script.
-	env::import_lib_from_path(&mut env, "\"profile.gynj\"");
+	// Try to execute the user's profile script.
+	if let Some(mut path) = home::home_dir() {
+		path.push(".gynjo_profile");
+		if let Ok(source) = std::fs::read_to_string(path) {
+			if let Err(err) = interpreter::eval(&mut env, &source) {
+				println!("Error in .gynjo_profile: {}", &err);
+			}
+		}
+	}
 	// Initial value of "ans" is ().
 	env.lock()
 		.unwrap()


### PR DESCRIPTION
This changes the name and location of the user script. Instead of reading `profile.gynj` from the current working directory, the interpreter will read `.gynjo_profile` from the user's home directory, if present. This also makes it not an error if the file is missing.